### PR TITLE
Fix: Added Enter key functionality to start test #61

### DIFF
--- a/pr-issue-61.md
+++ b/pr-issue-61.md
@@ -1,0 +1,16 @@
+## 📌 Description
+Implemented functionality that allows the user to start the typing test by pressing the `Enter` (`<Return>`) key instead of clicking the "Start Test" button with the mouse. This enables a more seamless and intuitive typing test workflow without taking hands off the keyboard.
+
+## 🔗 Related Issue
+Closes #61
+
+## 🛠 Changes Made
+- Bound the `<Return>` key to check if `self.start_button` is enabled.
+- Invokes `self.start_test()` if it is safe to start the test.
+
+## 📷 Screenshots (if applicable)
+
+## ✅ Checklist
+- [x] I have tested my changes
+- [x] I have linked the related issue
+- [x] My code follows project guidelines

--- a/typing_speed_test.py
+++ b/typing_speed_test.py
@@ -139,6 +139,12 @@ class TypingSpeedTest(ctk.CTk):
         )
         self.pause_button.grid(row=0, column=1, padx=10)
 
+        self.bind("<Return>", self.handle_enter)
+
+    def handle_enter(self, event=None):
+        if self.start_button.cget("state") == "normal":
+            self.start_test()
+
     # ======================
     # STREAK TEXT
     # ======================


### PR DESCRIPTION
## 📌 Description
Implemented functionality that allows the user to start the typing test by pressing the `Enter` (`<Return>`) key instead of clicking the "Start Test" button with the mouse. This enables a more seamless and intuitive typing test workflow without taking hands off the keyboard.

## 🔗 Related Issue
Closes #61 

## 🛠 Changes Made
- Bound the `<Return>` key to check if `self.start_button` is enabled.
- Invokes `self.start_test()` if it is safe to start the test.

## 📷 Screenshots (if applicable)
<img width="715" height="611" alt="image" src="https://github.com/user-attachments/assets/260b1e3f-6995-4f9d-8764-ddc25be090a9" />

## ✅ Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] My code follows project guidelines
